### PR TITLE
Update demo scripts to Python3 and eigenpy >= 2

### DIFF
--- a/momentumopt/python/momentumopt/kino_dyn_planner_solo.py
+++ b/momentumopt/python/momentumopt/kino_dyn_planner_solo.py
@@ -21,7 +21,7 @@ from momentumopt.motion_execution import MotionExecutor
 from momentumopt.kinoptpy.create_data_file import create_file, create_qp_files, create_lqr_files
 
 from momentumopt.motion_planner import MotionPlanner
-from quadruped.quadruped_wrapper import QuadrupedWrapper, Quadruped12Wrapper
+from .quadruped.quadruped_wrapper import QuadrupedWrapper, Quadruped12Wrapper
 
 import matplotlib.pyplot as plt
 

--- a/momentumopt/python/momentumopt/kino_dyn_planner_solo.py
+++ b/momentumopt/python/momentumopt/kino_dyn_planner_solo.py
@@ -24,6 +24,7 @@ from momentumopt.motion_planner import MotionPlanner
 from .quadruped.quadruped_wrapper import QuadrupedWrapper, Quadruped12Wrapper
 
 import matplotlib.pyplot as plt
+pin.switchToNumpyMatrix()
 
 def parse_arguments(argv):
     cfg_file = ''

--- a/momentumopt/python/momentumopt/kinoptpy/momentum_kinematics_optimizer.py
+++ b/momentumopt/python/momentumopt/kinoptpy/momentum_kinematics_optimizer.py
@@ -322,7 +322,7 @@ class MomentumKinematicsOptimizer(object):
         if iters == self.max_iterations - 1:
             print('Failed to converge for initial setup.')
 
-        print "initial configuration: \n", q
+        print("initial configuration: \n", q)
 
         self.q_init = q.copy()
         self.dq_init = dq.copy()

--- a/momentumopt/python/momentumopt/motion_execution.py
+++ b/momentumopt/python/momentumopt/motion_execution.py
@@ -17,8 +17,8 @@ from pinocchio.utils import zero
 
 from pymomentum import *
 
-from quadruped.quadruped_wrapper import QuadrupedWrapper
-from quadruped.simulator import Simulator
+from .quadruped.quadruped_wrapper import QuadrupedWrapper
+from .quadruped.simulator import Simulator
 from momentumopt.kinoptpy.utils import isfloat
 
 

--- a/momentumopt/python/momentumopt/motion_planner.py
+++ b/momentumopt/python/momentumopt/motion_planner.py
@@ -13,7 +13,7 @@ import time
 import numpy as np
 import matplotlib.pyplot as plt
 
-from quadruped.quadruped_wrapper import QuadrupedWrapper
+from .quadruped.quadruped_wrapper import QuadrupedWrapper
 from pysolver import *
 from pysolverlqr import *
 


### PR DESCRIPTION
Update some minor syntax of the python scripts required to run the demo 
`python3 ../nodes/kino_dyn_planner_solo -i ../config/cfg_solo_jump.yaml`

* Correctly add parentheses for print
* Use relative import for the quadruped package, as it is not installed in the PYTHONPATH but is in the folder  `momentumopt/python/momentumopt/`

I did not test it with Python 2. 

