### PR TITLE
Correctly use the w_com_track when update_tracking_objective==true

### DIFF
--- a/momentumopt/src/momentumopt/dynopt/DynamicsOptimizer.cpp
+++ b/momentumopt/src/momentumopt/dynopt/DynamicsOptimizer.cpp
@@ -56,7 +56,7 @@ namespace momentumopt {
 
   void DynamicsOptimizer::updateTrackingObjective()
   {
-    weight_desired_com_tracking_ = this->getSetting().get(PlannerVectorParam_WeightCenterOfMass);
+    weight_desired_com_tracking_ = this->getSetting().get(PlannerVectorParam_WeightDynamicTrackingCenterOfMass);
     this->getSetting().get(PlannerVectorParam_WeightLinearMomentum) = this->getSetting().get(PlannerVectorParam_WeightDynamicTrackingLinearMomentum);
 	  this->getSetting().get(PlannerVectorParam_WeightAngularMomentum) = this->getSetting().get(PlannerVectorParam_WeightDynamicTrackingAngularMomentum);
   }


### PR DESCRIPTION
I believe that this was a mistake, if not then I do not understand where this weight is used. In the current state of the code, the parameter `w_com_track` of the yaml file doesn't seems to be used anywhere. Only `w_com` was used. 