### PR TITLE
Data dump: Start timeseries from zero to avoid offset by one dt

### DIFF
--- a/momentumopt/python/momentumopt/motion_planner.py
+++ b/momentumopt/python/momentumopt/motion_planner.py
@@ -25,7 +25,6 @@ def create_time_vector(dynamics_sequence):
     num_time_steps = len(dynamics_sequence.dynamics_states)
     # Create time vector
     time = np.zeros((num_time_steps))
-    time[0] = dynamics_sequence.dynamics_states[0].dt
     for i in range(num_time_steps - 1):
         time[i + 1] = time[i] + dynamics_sequence.dynamics_states[i].dt
 


### PR DESCRIPTION
When looking at the result from the inverse kinematics and the finally dumped data, I noticed that the trajectory from the dumped data is time-shifted by one dt. See screenshot below where dt is 20 ms.

This PR fixes this and make sure the time series used for dumping the data starts at zero.

![image](https://user-images.githubusercontent.com/191719/112223565-7eca2e00-8c00-11eb-91cf-7d28c93d1ebc.png)
