### PR TITLE
KinOpt: Fix reference endeffector velocity

### DIFF
--- a/momentumopt/python/momentumopt/kinoptpy/momentum_kinematics_optimizer.py
+++ b/momentumopt/python/momentumopt/kinoptpy/momentum_kinematics_optimizer.py
@@ -117,7 +117,7 @@ class EndeffectorTrajectoryGenerator(object):
         for it in range(num_time_steps):
             for eff, name in enumerate(mom_kin_optimizer.eff_names):
                 endeff_pos_ref[it][eff] = [eff_traj_poly[name][i].eval(it) for i in range(3)]
-                endeff_vel_ref[it][eff] = [eff_traj_poly[name][i].deval(it) for i in range(3)]
+                endeff_vel_ref[it][eff] = [eff_traj_poly[name][i].deval(it)/dt for i in range(3)]
                 endeff_contact[it][eff] = self.is_end_eff_in_contact(it, eff, mom_kin_optimizer)
 
         return endeff_pos_ref, endeff_vel_ref, endeff_contact


### PR DESCRIPTION
As you can see in the screenshot from #48 , the reference and inverse kinematics trajectory for the endeffector do not align. Looking into this, it turns out the reference velocity for the endeffector was not computed properly: The polynominal gets differentiated but the dt spacing is not taken into account. This PR fixes this.

This seems to be a regression from the recent kindyn alignment change in #47. There, the polynominal time was changed from time `t` to time index `it`, causing the missing `dt` in the differentiation.

With this change, the reference and solution from the second order inverse kinematics align very much - see screenshot below.
![image](https://user-images.githubusercontent.com/191719/112361949-47b05700-8caa-11eb-8495-934d097059c4.png)


